### PR TITLE
Fix Imports and Packages

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -121,7 +121,7 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.probationbuddy.probationbuddy.MainActivity" />
         </activity>
-        <activity android:name=".calendarlog.CalendarLogActivity"></activity>
+        <activity android:name=".CalendarLog.CalendarLogActivity"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,20 +25,20 @@
         </activity>
 
         <service
-            android:name=".morningalarm.MorningService"
+            android:name=".MorningAlarm.MorningService"
             android:exported="false" />
 
         <receiver
-            android:name=".morningalarm.MorningReceiver"
+            android:name=".MorningAlarm.MorningReceiver"
             android:enabled="true"
             android:process=":remote" />
 
         <service
-            android:name=".morningalarm.MorningServiceStarter"
+            android:name=".MorningAlarm.MorningServiceStarter"
             android:exported="false" />
 
         <receiver
-            android:name=".morningalarm.MorningReceiverOnBoot"
+            android:name=".MorningAlarm.MorningReceiverOnBoot"
             android:enabled="true"
             android:exported="true">
             <intent-filter>
@@ -47,15 +47,15 @@
         </receiver>
 
         <service
-            android:name=".dayalarm.DayAlarmService"
+            android:name=".DayAlarm.DayAlarmService"
             android:exported="false" />
 
         <receiver
-            android:name=".dayalarm.DayAlarmReceiver"
+            android:name=".DayAlarm.DayAlarmReceiver"
             android:enabled="true"
             android:process=":remote" />
         <receiver
-            android:name=".dayalarm.DayAlarmOnBoot"
+            android:name=".DayAlarm.DayAlarmOnBoot"
             android:enabled="true"
             android:exported="true">
             <intent-filter>
@@ -64,20 +64,20 @@
         </receiver>
 
         <service
-            android:name=".gotestalarm.GoTestAlarmStarter"
+            android:name=".GoTestAlarm.GoTestAlarmStarter"
             android:exported="false" />
 
         <receiver
-            android:name=".gotestalarm.GoTestAlarmReceiver"
+            android:name=".GoTestAlarm.GoTestAlarmReceiver"
             android:enabled="true"
             android:process=":remote" />
 
         <service
-            android:name=".gotestalarm.GoTestAlarmService"
+            android:name=".GoTestAlarm.GoTestAlarmService"
             android:exported="false" />
 
         <receiver
-            android:name=".gotestalarm.GoTestAlarmOnBoot"
+            android:name=".GoTestAlarm.GoTestAlarmOnBoot"
             android:enabled="true"
             android:exported="true">
             <intent-filter>
@@ -86,11 +86,11 @@
         </receiver>
 
         <service
-            android:name=".call.CallingService"
+            android:name=".Call.CallingService"
             android:enabled="true"
             android:exported="false" />
         <service
-            android:name=".services.HideNotificationService"
+            android:name=".Services.HideNotificationService"
             android:exported="false" />
 
         <activity
@@ -109,7 +109,7 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.probationbuddy.probationbuddy.MainActivity" />
         </activity>
-        <activity android:name=".call.CallActivity2">
+        <activity android:name=".Call.CallActivity2">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.probationbuddy.probationbuddy.MainActivity" />

--- a/app/src/main/java/com/probationbuddy/probationbuddy/Call/CallActivity2.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/Call/CallActivity2.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.call;
+package com.probationbuddy.probationbuddy.Call;
 
 import android.Manifest;
 import android.app.NotificationManager;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/Call/CallingService.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/Call/CallingService.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.call;
+package com.probationbuddy.probationbuddy.Call;
 
 import android.app.Notification;
 import android.app.NotificationManager;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/Call/MyPhoneListener.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/Call/MyPhoneListener.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.call;
+package com.probationbuddy.probationbuddy.Call;
 
 import android.content.Context;
 import android.content.Intent;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/DayAlarm/DayAlarmOnBoot.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/DayAlarm/DayAlarmOnBoot.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.dayalarm;
+package com.probationbuddy.probationbuddy.DayAlarm;
 
 import android.content.Context;
 import android.content.Intent;
@@ -7,7 +7,7 @@ import android.support.v4.content.WakefulBroadcastReceiver;
 import android.support.v7.preference.PreferenceManager;
 import android.util.Log;
 
-import com.probationbuddy.probationbuddy.morningalarm.MorningService;
+import com.probationbuddy.probationbuddy.MorningAlarm.MorningService;
 
 public class DayAlarmOnBoot extends WakefulBroadcastReceiver {
     SharedPreferences sharedPrefs;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/DayAlarm/DayAlarmReceiver.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/DayAlarm/DayAlarmReceiver.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.dayalarm;
+package com.probationbuddy.probationbuddy.DayAlarm;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/DayAlarm/DayAlarmService.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/DayAlarm/DayAlarmService.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.dayalarm;
+package com.probationbuddy.probationbuddy.DayAlarm;
 
 import android.app.IntentService;
 import android.app.NotificationManager;
@@ -15,11 +15,11 @@ import android.support.v7.app.NotificationCompat;
 import android.support.v7.preference.PreferenceManager;
 import android.util.Log;
 
-import com.probationbuddy.probationbuddy.call.CallActivity2;
+import com.probationbuddy.probationbuddy.Call.CallActivity2;
 import com.probationbuddy.probationbuddy.DoYouTestActivity;
 import com.probationbuddy.probationbuddy.MainActivity;
 import com.probationbuddy.probationbuddy.R;
-import com.probationbuddy.probationbuddy.services.HideNotificationService;
+import com.probationbuddy.probationbuddy.Services.HideNotificationService;
 
 public class DayAlarmService extends IntentService {
     int mId = 100;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/DoYouTestActivity.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/DoYouTestActivity.java
@@ -18,11 +18,11 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.probationbuddy.probationbuddy.calendarlog.CalendarLogActivity;
-import com.probationbuddy.probationbuddy.call.CallActivity2;
-import com.probationbuddy.probationbuddy.call.CallingService;
-import com.probationbuddy.probationbuddy.dayalarm.DayAlarmReceiver;
-import com.probationbuddy.probationbuddy.gotestalarm.GoTestAlarmStarter;
-import com.probationbuddy.probationbuddy.services.HideNotificationService;
+import com.probationbuddy.probationbuddy.Call.CallActivity2;
+import com.probationbuddy.probationbuddy.Call.CallingService;
+import com.probationbuddy.probationbuddy.DayAlarm.DayAlarmReceiver;
+import com.probationbuddy.probationbuddy.GoTestAlarm.GoTestAlarmStarter;
+import com.probationbuddy.probationbuddy.Services.HideNotificationService;
 
 public class DoYouTestActivity extends AppCompatActivity {
     Context mContext = this;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/DoYouTestActivity.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/DoYouTestActivity.java
@@ -17,7 +17,7 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.probationbuddy.probationbuddy.calendarlog.CalendarLogActivity;
+import com.probationbuddy.probationbuddy.CalendarLog.CalendarLogActivity;
 import com.probationbuddy.probationbuddy.Call.CallActivity2;
 import com.probationbuddy.probationbuddy.Call.CallingService;
 import com.probationbuddy.probationbuddy.DayAlarm.DayAlarmReceiver;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/GoTestAlarm/GoTestAlarmOnBoot.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/GoTestAlarm/GoTestAlarmOnBoot.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.gotestalarm;
+package com.probationbuddy.probationbuddy.GoTestAlarm;
 
 import android.content.Context;
 import android.content.Intent;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/GoTestAlarm/GoTestAlarmReceiver.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/GoTestAlarm/GoTestAlarmReceiver.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.gotestalarm;
+package com.probationbuddy.probationbuddy.GoTestAlarm;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/GoTestAlarm/GoTestAlarmService.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/GoTestAlarm/GoTestAlarmService.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.gotestalarm;
+package com.probationbuddy.probationbuddy.GoTestAlarm;
 
 import android.app.IntentService;
 import android.app.NotificationManager;
@@ -16,7 +16,7 @@ import android.util.Log;
 import com.probationbuddy.probationbuddy.MainActivity;
 import com.probationbuddy.probationbuddy.R;
 import com.probationbuddy.probationbuddy.TestDoneActivity;
-import com.probationbuddy.probationbuddy.services.HideNotificationService;
+import com.probationbuddy.probationbuddy.Services.HideNotificationService;
 
 public class GoTestAlarmService extends IntentService {
     int mId;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/GoTestAlarm/GoTestAlarmStarter.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/GoTestAlarm/GoTestAlarmStarter.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.gotestalarm;
+package com.probationbuddy.probationbuddy.GoTestAlarm;
 
 import android.app.AlarmManager;
 import android.app.IntentService;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/MainActivity.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/MainActivity.java
@@ -21,11 +21,11 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
-import com.probationbuddy.probationbuddy.call.CallActivity2;
-import com.probationbuddy.probationbuddy.dayalarm.DayAlarmReceiver;
-import com.probationbuddy.probationbuddy.gotestalarm.GoTestAlarmReceiver;
-import com.probationbuddy.probationbuddy.morningalarm.MorningReceiver;
-import com.probationbuddy.probationbuddy.morningalarm.MorningServiceStarter;
+import com.probationbuddy.probationbuddy.Call.CallActivity2;
+import com.probationbuddy.probationbuddy.DayAlarm.DayAlarmReceiver;
+import com.probationbuddy.probationbuddy.GoTestAlarm.GoTestAlarmReceiver;
+import com.probationbuddy.probationbuddy.MorningAlarm.MorningReceiver;
+import com.probationbuddy.probationbuddy.MorningAlarm.MorningServiceStarter;
 import com.probationbuddy.probationbuddy.settings.SettingsFragment;
 
 import static com.probationbuddy.probationbuddy.R.id.bug;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/MainActivity.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/MainActivity.java
@@ -26,7 +26,7 @@ import com.probationbuddy.probationbuddy.DayAlarm.DayAlarmReceiver;
 import com.probationbuddy.probationbuddy.GoTestAlarm.GoTestAlarmReceiver;
 import com.probationbuddy.probationbuddy.MorningAlarm.MorningReceiver;
 import com.probationbuddy.probationbuddy.MorningAlarm.MorningServiceStarter;
-import com.probationbuddy.probationbuddy.settings.SettingsFragment;
+import com.probationbuddy.probationbuddy.Settings.SettingsFragment;
 
 import static com.probationbuddy.probationbuddy.R.id.bug;
 

--- a/app/src/main/java/com/probationbuddy/probationbuddy/MorningAlarm/MorningReceiver.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/MorningAlarm/MorningReceiver.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.morningalarm;
+package com.probationbuddy.probationbuddy.MorningAlarm;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/MorningAlarm/MorningReceiverOnBoot.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/MorningAlarm/MorningReceiverOnBoot.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.morningalarm;
+package com.probationbuddy.probationbuddy.MorningAlarm;
 
 import android.content.Context;
 import android.content.Intent;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/MorningAlarm/MorningService.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/MorningAlarm/MorningService.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.morningalarm;
+package com.probationbuddy.probationbuddy.MorningAlarm;
 
 import android.app.AlarmManager;
 import android.app.IntentService;
@@ -8,7 +8,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.support.v7.preference.PreferenceManager;
 
-import com.probationbuddy.probationbuddy.dayalarm.DayAlarmReceiver;
+import com.probationbuddy.probationbuddy.DayAlarm.DayAlarmReceiver;
 
 
 // MorningService makes the alarm to give repeating notification reminders

--- a/app/src/main/java/com/probationbuddy/probationbuddy/MorningAlarm/MorningServiceStarter.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/MorningAlarm/MorningServiceStarter.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.morningalarm;
+package com.probationbuddy.probationbuddy.MorningAlarm;
 
 import android.app.AlarmManager;
 import android.app.IntentService;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/Services/HideNotificationService.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/Services/HideNotificationService.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.services;
+package com.probationbuddy.probationbuddy.Services;
 
 import android.app.IntentService;
 import android.app.NotificationManager;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/TestDoneActivity.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/TestDoneActivity.java
@@ -17,7 +17,7 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import com.probationbuddy.probationbuddy.calendarlog.CalendarLogActivity;
-import com.probationbuddy.probationbuddy.gotestalarm.GoTestAlarmReceiver;
+import com.probationbuddy.probationbuddy.GoTestAlarm.GoTestAlarmReceiver;
 
 public class TestDoneActivity extends AppCompatActivity {
     Button testDoneButton;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/TestDoneActivity.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/TestDoneActivity.java
@@ -16,7 +16,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
 
-import com.probationbuddy.probationbuddy.calendarlog.CalendarLogActivity;
+import com.probationbuddy.probationbuddy.CalendarLog.CalendarLogActivity;
 import com.probationbuddy.probationbuddy.GoTestAlarm.GoTestAlarmReceiver;
 
 public class TestDoneActivity extends AppCompatActivity {

--- a/app/src/main/java/com/probationbuddy/probationbuddy/calendarlog/CalendarLogActivity.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/calendarlog/CalendarLogActivity.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.calendarlog;
+package com.probationbuddy.probationbuddy.CalendarLog;
 
 import android.content.Intent;
 import android.os.Bundle;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/settings/SettingsFragment.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/settings/SettingsFragment.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.settings;
+package com.probationbuddy.probationbuddy.Settings;
 
 import android.app.Activity;
 import android.content.DialogInterface;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/settings/SettingsFragment.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/settings/SettingsFragment.java
@@ -21,7 +21,7 @@ import android.widget.Toast;
 import com.probationbuddy.probationbuddy.MainActivity;
 import com.probationbuddy.probationbuddy.R;
 import com.probationbuddy.probationbuddy.TestDoneActivity;
-import com.probationbuddy.probationbuddy.call.CallActivity2;
+import com.probationbuddy.probationbuddy.Call.CallActivity2;
 
 import static android.support.v7.preference.PreferenceManager.getDefaultSharedPreferences;
 

--- a/app/src/main/java/com/probationbuddy/probationbuddy/settings/TimePreference.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/settings/TimePreference.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.settings;
+package com.probationbuddy.probationbuddy.Settings;
 
 import android.content.Context;
 import android.content.res.TypedArray;

--- a/app/src/main/java/com/probationbuddy/probationbuddy/settings/TimePreferenceDialogFragmentCompat.java
+++ b/app/src/main/java/com/probationbuddy/probationbuddy/settings/TimePreferenceDialogFragmentCompat.java
@@ -1,4 +1,4 @@
-package com.probationbuddy.probationbuddy.settings;
+package com.probationbuddy.probationbuddy.Settings;
 
 import android.os.Build;
 import android.os.Bundle;

--- a/app/src/main/res/layout/activity_calendar_log.xml
+++ b/app/src/main/res/layout/activity_calendar_log.xml
@@ -8,6 +8,6 @@
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context="com.probationbuddy.probationbuddy.calendarlog.CalendarLogActivity">
+    tools:context="com.probationbuddy.probationbuddy.CalendarLog.CalendarLogActivity">
 
 </RelativeLayout>

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -28,7 +28,7 @@
         android:title="Your call-in number" />
 
 
-    <com.probationbuddy.probationbuddy.settings.TimePreference
+    <com.probationbuddy.probationbuddy.Settings.TimePreference
         style="@style/AppPreference.DialogPreference"
         android:defaultValue="660"
         android:dialogIcon="@drawable/ic_access_time_black_48dp"


### PR DESCRIPTION
Again this is based on my get-it-running branch, but could be cherry-picked to a master branch if you want them alone!

This fixes some of the package names and imports. Lots of the files had red errors in Android Studio due to the folder directories being in TitleCase but the package names being in all lowercase. I fixed this by making all the directories TitleCase and all the package names TitleCase to match. Now non of the files come up red in Android Studio!